### PR TITLE
Use proxy for all subdomains except some publicly accessible ones

### DIFF
--- a/proxy.pac
+++ b/proxy.pac
@@ -1,26 +1,25 @@
 function FindProxyForURL (url, host) {
+  // These hosts are publicly accessible
   if ([
-       'registry.desy.de'
-      ,'callmgr.desy.de'
-      ,'exflserv05.desy.de'
-      ,'exflserv06.desy.de'
-      ,'exflmon01.desy.de'
-      ,'exflrtdtest.desy.de'
-      ,'dachs.desy.de'
-      ,'darf-dachs.desy.de'
-      ,'ias.desy.de'
-      ,'131.169.203.96'
-      ,'exfldadev01.desy.de'
-      ,'devpi.exfldadev01.desy.de'
-      ,'passman.xfel.eu'
-      ,'remcom.xfel.eu'
-      ,'ctrend.xfel.eu'
-      ,'max-exfl016.desy.de'
-      ,'max-exfl017.desy.de'
-      ,'exflocdm.desy.de'
-      ,'max-exfl-display001.desy.de'
-      ,'max-exfl-display002.desy.de'
-     ].indexOf(host) >= 0) {
+       'xfel.eu',
+      ,'www.xfel.eu'
+      ,'in.xfel.eu'
+      ,'git.xfel.eu'
+      ,'rtd.xfel.eu'
+      ,'desy.de'
+      ,'www.desy.de'
+      ,'it.desy.de'
+      ,'mail.desy.de'
+      ,'passwd.desy.de'
+      ,'max-display.desy.de'
+      ,'max-exfl-display.desy.de'
+      ,'max-jhub.desy.de'
+      ,'bastion.desy.de'
+     ].indexOf(host) >= 0 {
+    return 'DIRECT';
+  }
+  // Proxy for everything else under .desy.de or .xfel.eu
+  if (/(\.desy\.de|\.xfel\.eu)$/.test(host)) {
     return 'SOCKS localhost:22222';
   }
 

--- a/proxy.pac
+++ b/proxy.pac
@@ -7,6 +7,7 @@ function FindProxyForURL (url, host) {
       ,'git.xfel.eu'
       ,'rtd.xfel.eu'
       ,'syncandshare.xfel.eu'
+      ,'redmine.xfel.eu'
       ,'desy.de'
       ,'www.desy.de'
       ,'it.desy.de'

--- a/proxy.pac
+++ b/proxy.pac
@@ -6,6 +6,7 @@ function FindProxyForURL (url, host) {
       ,'in.xfel.eu'
       ,'git.xfel.eu'
       ,'rtd.xfel.eu'
+      ,'syncandshare.xfel.eu'
       ,'desy.de'
       ,'www.desy.de'
       ,'it.desy.de'

--- a/proxy.pac
+++ b/proxy.pac
@@ -1,7 +1,7 @@
 function FindProxyForURL (url, host) {
   // These hosts are publicly accessible
   if ([
-       'xfel.eu',
+       'xfel.eu'
       ,'www.xfel.eu'
       ,'in.xfel.eu'
       ,'git.xfel.eu'
@@ -15,7 +15,7 @@ function FindProxyForURL (url, host) {
       ,'max-exfl-display.desy.de'
       ,'max-jhub.desy.de'
       ,'bastion.desy.de'
-     ].indexOf(host) >= 0 {
+     ].indexOf(host) >= 0) {
     return 'DIRECT';
   }
   // Proxy for everything else under .desy.de or .xfel.eu

--- a/proxy.pac
+++ b/proxy.pac
@@ -4,6 +4,7 @@ function FindProxyForURL (url, host) {
        'xfel.eu'
       ,'www.xfel.eu'
       ,'in.xfel.eu'
+      ,'docs.xfel.eu'
       ,'git.xfel.eu'
       ,'rtd.xfel.eu'
       ,'syncandshare.xfel.eu'


### PR DESCRIPTION
Rather than listing names which we do need the proxy for, list names that we can access directly.