### PR TITLE
Add s3.desy.de to the whitelist

### DIFF
--- a/proxy.pac
+++ b/proxy.pac
@@ -28,6 +28,7 @@ function FindProxyForURL (url, host) {
       ,'rt-system.desy.de'
       ,'chat.desy.de'
       ,'indico.desy.de'
+      ,'s3.desy.de'
      ].indexOf(host) >= 0) {
     return 'DIRECT';
   }


### PR DESCRIPTION
This is used by Hedgedoc when an image is uploaded.